### PR TITLE
Scale down player and enemy sprites by 20%

### DIFF
--- a/src/entities/Player.js
+++ b/src/entities/Player.js
@@ -42,12 +42,14 @@ export default class Player extends Phaser.Physics.Arcade.Sprite {
     scene.add.existing(this);
     scene.physics.add.existing(this);
 
+    const scale = 0.8;
+    this.setScale(scale);
     this.setOrigin(0.5, 1);
     this.setCollideWorldBounds(true);
     this.setDepth(1);
     // Trim transparent bounds so Lenny's feet sit flush with the ground
-    this.body.setSize(48, 45);
-    this.body.setOffset(10, 6);
+    this.body.setSize(48 * scale, 45 * scale);
+    this.body.setOffset(10 * scale, 6 * scale);
 
     this.cursors = scene.input.keyboard.createCursorKeys();
     this.jumpSound = scene.sound.add('jump');


### PR DESCRIPTION
## Summary
- Shrink Lenny by applying an 0.8 scale and adjust his physics body so the visual and collision sizes match
- Sockroach inherits the player's reduced height, keeping the enemy proportionally smaller

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af1683c028832abcc3ead8cfce58d7