### PR TITLE
Centralize asset loading with manifest and boot/preload scenes

### DIFF
--- a/src/assets/manifest.js
+++ b/src/assets/manifest.js
@@ -1,0 +1,40 @@
+const manifest = {
+  images: [
+    { key: 'lenny_idle', url: 'src/assets/sprites/lenny/grey_idle.PNG' },
+    { key: 'lenny_jump_1', url: 'src/assets/sprites/lenny/grey_jump_1.PNG' },
+    { key: 'lenny_jump_2', url: 'src/assets/sprites/lenny/grey_jump_2.PNG' },
+    { key: 'lenny_walk_1', url: 'src/assets/sprites/lenny/grey_walk_1.PNG' },
+    { key: 'lenny_walk_2', url: 'src/assets/sprites/lenny/grey_walk_2.PNG' },
+    { key: 'lenny_walk_3', url: 'src/assets/sprites/lenny/grey_walk_3.PNG' },
+    { key: 'lenny_walk_4', url: 'src/assets/sprites/lenny/grey_walk_4.PNG' },
+    { key: 'lenny_walk_5', url: 'src/assets/sprites/lenny/grey_walk_5.PNG' },
+    { key: 'lenny_walk_6', url: 'src/assets/sprites/lenny/grey_walk_6.PNG' },
+    { key: 'lenny_walk_7', url: 'src/assets/sprites/lenny/grey_walk_7.PNG' },
+    { key: 'lenny_walk_8', url: 'src/assets/sprites/lenny/grey_walk_8.PNG' },
+    { key: 'sockroach_walk_1', url: 'src/assets/sprites/sockroach/sockroach_walk_1.png' },
+    { key: 'sockroach_walk_2', url: 'src/assets/sprites/sockroach/sockroach_walk_2.png' },
+    { key: 'sockroach_walk_3', url: 'src/assets/sprites/sockroach/sockroach_walk_3.png' },
+    { key: 'sockroach_walk_4', url: 'src/assets/sprites/sockroach/sockroach_walk_4.png' },
+    { key: 'sockroach_walk_5', url: 'src/assets/sprites/sockroach/sockroach_walk_5.png' },
+    { key: 'sockroach_walk_6', url: 'src/assets/sprites/sockroach/sockroach_walk_6.png' },
+    { key: 'sockroach_stomp_1', url: 'src/assets/sprites/sockroach/sockroach_stomp_1.png' },
+    { key: 'sockroach_stomp_2', url: 'src/assets/sprites/sockroach/sockroach_stomp_2.png' },
+    { key: 'toast', url: 'src/assets/sprites/toast/toast_sprite.png' },
+    { key: 'lenny_face', url: 'src/assets/sprites/lenny/lenny_face.png' },
+    { key: 'tiles', url: 'src/levels/level1/nature-paltformer-tileset-16x16.png' }
+  ],
+  audio: [
+    { key: 'jump', url: 'src/assets/audio/cartoon-jump-6462.mp3' },
+    { key: 'bgm', url: 'src/assets/audio/Pixel Jump Groove.mp3' },
+    { key: 'toastCollect', url: 'src/assets/audio/toast-collect.mp3' },
+    { key: 'hurt', url: 'src/assets/audio/Hurt.wav' },
+    { key: 'landEnemy', url: 'src/assets/audio/LandOnEnemy.wav' },
+    { key: 'death', url: 'src/assets/audio/game-over-38511.mp3' },
+    { key: 'respawn', url: 'src/assets/audio/a_bulldog_respawning.mp3' }
+  ],
+  tilemaps: [
+    { key: 'level1', url: 'src/levels/level1/lennyTest.tmj' }
+  ]
+};
+
+export default manifest;

--- a/src/entities/Player.js
+++ b/src/entities/Player.js
@@ -1,17 +1,4 @@
 export default class Player extends Phaser.Physics.Arcade.Sprite {
-  static preload(scene) {
-    scene.load.image('lenny_idle', 'src/assets/sprites/lenny/grey_idle.PNG');
-    scene.load.image('lenny_jump_1', 'src/assets/sprites/lenny/grey_jump_1.PNG');
-    scene.load.image('lenny_jump_2', 'src/assets/sprites/lenny/grey_jump_2.PNG');
-    for (let i = 1; i <= 8; i++) {
-      scene.load.image(
-        `lenny_walk_${i}`,
-        `src/assets/sprites/lenny/grey_walk_${i}.PNG`
-      );
-    }
-    scene.load.audio('jump', 'src/assets/audio/cartoon-jump-6462.mp3');
-  }
-
   static createAnimations(scene) {
     scene.anims.create({
       key: 'idle',

--- a/src/entities/Sockroach.js
+++ b/src/entities/Sockroach.js
@@ -1,19 +1,4 @@
 export default class Sockroach extends Phaser.Physics.Arcade.Sprite {
-  static preload(scene) {
-    for (let i = 1; i <= 6; i++) {
-      scene.load.image(
-        `sockroach_walk_${i}`,
-        `src/assets/sprites/sockroach/sockroach_walk_${i}.png`
-      );
-    }
-    for (let i = 1; i <= 2; i++) {
-      scene.load.image(
-        `sockroach_stomp_${i}`,
-        `src/assets/sprites/sockroach/sockroach_stomp_${i}.png`
-      );
-    }
-  }
-
   static createAnimations(scene) {
     scene.anims.create({
       key: 'sockroach_walk',

--- a/src/game.js
+++ b/src/game.js
@@ -1,4 +1,6 @@
 import { VERSION, GAME_WIDTH, GAME_HEIGHT } from './constants.js';
+import BootScene from './scenes/BootScene.js';
+import PreloadScene from './scenes/PreloadScene.js';
 import Level1Scene from './scenes/Level1Scene.js';
 
 document.title = `Lenny Toast Adventure ${VERSION}`;
@@ -13,7 +15,7 @@ const config = {
     default: 'arcade',
     arcade: { gravity: { y: 700 } }
   },
-  scene: [Level1Scene]
+  scene: [BootScene, PreloadScene, Level1Scene]
 };
 
 new Phaser.Game(config);

--- a/src/scenes/BootScene.js
+++ b/src/scenes/BootScene.js
@@ -1,0 +1,16 @@
+/* global Phaser */
+import manifest from '../assets/manifest.js';
+
+export default class BootScene extends Phaser.Scene {
+  constructor() {
+    super('Boot');
+  }
+
+  preload() {
+    this.registry.set('manifest', manifest);
+  }
+
+  create() {
+    this.scene.start('Preload');
+  }
+}

--- a/src/scenes/Level1Scene.js
+++ b/src/scenes/Level1Scene.js
@@ -8,29 +8,6 @@ export default class Level1Scene extends Phaser.Scene {
     super('Level1');
   }
 
-  preload() {
-    this.load.tilemapTiledJSON(
-      'level1',
-      'src/levels/level1/lennyTest.tmj'
-    );
-    this.load.image(
-      'tiles',
-      'src/levels/level1/nature-paltformer-tileset-16x16.png'
-    );
-
-    Player.preload(this);
-    Sockroach.preload(this);
-    this.load.image('toast', 'src/assets/sprites/toast/toast_sprite.png');
-    this.load.image('lenny_face', 'src/assets/sprites/lenny/lenny_face.png');
-
-    this.load.audio('bgm', 'src/assets/audio/Pixel Jump Groove.mp3');
-    this.load.audio('toastCollect', 'src/assets/audio/toast-collect.mp3');
-    this.load.audio('hurt', 'src/assets/audio/Hurt.wav');
-    this.load.audio('landEnemy', 'src/assets/audio/LandOnEnemy.wav');
-    this.load.audio('death', 'src/assets/audio/game-over-38511.mp3');
-    this.load.audio('respawn', 'src/assets/audio/a_bulldog_respawning.mp3');
-  }
-
   create() {
     // --- Map + tiles ---
     const map = this.make.tilemap({ key: 'level1' });

--- a/src/scenes/PreloadScene.js
+++ b/src/scenes/PreloadScene.js
@@ -1,0 +1,28 @@
+/* global Phaser */
+export default class PreloadScene extends Phaser.Scene {
+  constructor() {
+    super('Preload');
+  }
+
+  preload() {
+    const manifest = this.registry.get('manifest');
+
+    const { width, height } = this.scale;
+    const progressBar = this.add.graphics();
+    this.load.on('progress', value => {
+      progressBar.clear();
+      progressBar.fillStyle(0xffffff, 1);
+      progressBar.fillRect(0, height / 2, width * value, 30);
+    });
+
+    manifest.images.forEach(asset => this.load.image(asset.key, asset.url));
+    manifest.audio.forEach(asset => this.load.audio(asset.key, asset.url));
+    manifest.tilemaps.forEach(asset =>
+      this.load.tilemapTiledJSON(asset.key, asset.url)
+    );
+  }
+
+  create() {
+    this.scene.start('Level1');
+  }
+}


### PR DESCRIPTION
## Summary
- Introduce `assets/manifest.js` listing all images, audio, and tilemaps
- Add Boot and Preload scenes to load assets once and show progress
- Remove ad-hoc preload calls so Level1 and entities assume assets are present

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af49d80618832ab9749ffe04528140