### PR TITLE
Add AudioBus to manage audio playback

### DIFF
--- a/src/AudioBus.js
+++ b/src/AudioBus.js
@@ -1,0 +1,34 @@
+const sfxCache = {};
+let soundManager;
+let currentMusic = null;
+
+export function init(scene) {
+  soundManager = scene.sound;
+}
+
+export function sfx(key, config) {
+  if (!soundManager) return null;
+  let sound = sfxCache[key];
+  if (!sound) {
+    sound = soundManager.add(key, config);
+    sfxCache[key] = sound;
+  }
+  if (!sound.isPlaying) {
+    sound.play();
+  }
+  return sound;
+}
+
+export function music(key, config = { loop: true }) {
+  if (!soundManager) return null;
+  if (currentMusic && currentMusic.key === key && currentMusic.sound.isPlaying) {
+    return currentMusic.sound;
+  }
+  if (currentMusic && currentMusic.sound.isPlaying) {
+    currentMusic.sound.stop();
+  }
+  const sound = soundManager.add(key, config);
+  sound.play();
+  currentMusic = { key, sound };
+  return sound;
+}

--- a/src/entities/Player.js
+++ b/src/entities/Player.js
@@ -1,3 +1,5 @@
+import { sfx } from '../AudioBus.js';
+
 export default class Player extends Phaser.Physics.Arcade.Sprite {
   static preload(scene) {
     scene.load.image('lenny_idle', 'src/assets/sprites/lenny/grey_idle.PNG');
@@ -52,7 +54,6 @@ export default class Player extends Phaser.Physics.Arcade.Sprite {
     this.body.setOffset(10 * scale, 18 * scale);
 
     this.cursors = scene.input.keyboard.createCursorKeys();
-    this.jumpSound = scene.sound.add('jump');
     this.jumpCount = 0;
   }
 
@@ -76,7 +77,7 @@ export default class Player extends Phaser.Physics.Arcade.Sprite {
     const jumpPressed = Phaser.Input.Keyboard.JustDown(this.cursors.up);
     if (jumpPressed && (onGround || this.jumpCount < 2)) {
       this.setVelocityY(-450);
-      this.jumpSound.play();
+      sfx('jump');
       this.jumpCount++;
       this.anims.stop();
       this.setTexture('lenny_jump_1');

--- a/src/scenes/Level1Scene.js
+++ b/src/scenes/Level1Scene.js
@@ -2,6 +2,7 @@
 import Player from '../entities/Player.js';
 import Sockroach from '../entities/Sockroach.js';
 import { GAME_WIDTH, GAME_HEIGHT } from '../constants.js';
+import { init as audioInit, sfx, music } from '../AudioBus.js';
 
 export default class Level1Scene extends Phaser.Scene {
   constructor() {
@@ -32,6 +33,7 @@ export default class Level1Scene extends Phaser.Scene {
   }
 
   create() {
+    audioInit(this);
     // --- Map + tiles ---
     const map = this.make.tilemap({ key: 'level1' });
     const tiles = map.addTilesetImage(
@@ -105,13 +107,7 @@ export default class Level1Scene extends Phaser.Scene {
     if (platforms) this.physics.add.collider(this.enemies, platforms);
 
     // --- Audio ---
-    this.toastSound = this.sound.add('toastCollect');
-    this.bgm = this.sound.add('bgm', { loop: true, volume: 0.5 });
-    this.hurtSound = this.sound.add('hurt');
-    this.landEnemySound = this.sound.add('landEnemy');
-    this.deathSound = this.sound.add('death');
-    this.respawnSound = this.sound.add('respawn');
-    this.bgm.play();
+    this.bgm = music('bgm', { loop: true, volume: 0.5 });
 
     // --- Parse Entities: enemies + collectibles ---
     if (entities) {
@@ -248,7 +244,7 @@ export default class Level1Scene extends Phaser.Scene {
       playerObj.body.prev.y < playerObj.body.y;
 
     if (falling && playerBottom <= enemyTop + 5) {
-      this.landEnemySound.play();
+      sfx('landEnemy');
       enemy.alive = false;
       enemy.play('sockroach_stomp');
       enemy.setVelocity(0, 0);
@@ -261,7 +257,7 @@ export default class Level1Scene extends Phaser.Scene {
       });
     } else {
       if (this.isInvincible) return;
-      this.hurtSound.play();
+      sfx('hurt');
       this.health -= 1;
       this.removeHealthIcon();
       this.isInvincible = true;
@@ -294,7 +290,7 @@ export default class Level1Scene extends Phaser.Scene {
       duration: 300,
       onComplete: () => toast.destroy()
     });
-    this.toastSound.play();
+    sfx('toastCollect');
     this.toastCount += toast.value;
     this.toastText.setText(`${this.toastCount}`);
     this.tweens.add({
@@ -348,7 +344,7 @@ export default class Level1Scene extends Phaser.Scene {
     if (this.isDead) return;
     this.isDead = true;
     this.bgm.stop();
-    this.deathSound.play();
+    sfx('death');
     this.player.setVelocity(0, 0);
     this.player.anims.stop();
     this.player.setTexture('lenny_idle');
@@ -364,8 +360,8 @@ export default class Level1Scene extends Phaser.Scene {
         this.player.jumpCount = 0;
         this.health = 3;
         this.resetHealthIcons();
-        this.respawnSound.play();
-        this.respawnSound.once('complete', () => {
+        const respawn = sfx('respawn');
+        respawn.once('complete', () => {
           this.bgm.setVolume(0);
           this.bgm.play();
           this.tweens.add({


### PR DESCRIPTION
## Summary
- introduce AudioBus helper with `sfx` and `music` utilities that cache effects and ensure only one music track
- route Player and Level1Scene audio through the bus to prevent overlapping SFX and duplicate BGM

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af4a1185e8832a82f0dc87c2159cf5