### PR TITLE
Ensure deterministic movement using delta time and clamped velocities

### DIFF
--- a/src/entities/Player.js
+++ b/src/entities/Player.js
@@ -46,7 +46,7 @@ export default class Player extends Phaser.Physics.Arcade.Sprite {
     this.jumpCount = 0;
   }
 
-  update() {
+  update(delta) {
     const onGround = this.body.blocked.down;
     if (onGround) this.jumpCount = 0;
 
@@ -80,5 +80,11 @@ export default class Player extends Phaser.Physics.Arcade.Sprite {
         this.setTexture('lenny_jump_2');
       }
     }
+
+    // Clamp velocities to keep movement deterministic and avoid frame-rate spikes
+    const maxX = 160;
+    const maxY = 600;
+    this.body.velocity.x = Phaser.Math.Clamp(this.body.velocity.x, -maxX, maxX);
+    this.body.velocity.y = Phaser.Math.Clamp(this.body.velocity.y, -maxY, maxY);
   }
 }

--- a/src/entities/Sockroach.js
+++ b/src/entities/Sockroach.js
@@ -50,13 +50,27 @@ export default class Sockroach extends Phaser.Physics.Arcade.Sprite {
     this.alive = true;
   }
 
-  update() {
+  update(_, delta) {
     if (!this.alive) return;
-    if (this.x <= this.patrolLeft) {
+
+    const dt = (delta / 1000) * this.scene.physics.world.timeScale;
+    const nextX = this.x + this.body.velocity.x * dt;
+
+    if (nextX <= this.patrolLeft) {
+      this.x = this.patrolLeft;
       this.setVelocityX(this.speed);
-    } else if (this.x >= this.patrolRight) {
+    } else if (nextX >= this.patrolRight) {
+      this.x = this.patrolRight;
       this.setVelocityX(-this.speed);
     }
+
+    // Clamp velocity to avoid frame-rate spikes
+    this.body.velocity.x = Phaser.Math.Clamp(
+      this.body.velocity.x,
+      -this.speed,
+      this.speed
+    );
+
     this.flipX = this.body.velocity.x < 0;
   }
 }

--- a/src/scenes/BaseLevelScene.js
+++ b/src/scenes/BaseLevelScene.js
@@ -221,8 +221,9 @@ export default class BaseLevelScene extends Phaser.Scene {
     return toast;
   }
 
-  update() {
-    this.player.update();
+  update(time, delta) {
+    this.player.update(delta);
+    const dt = (delta / 1000) * this.physics.world.timeScale;
     this.enemies.children.iterate(e => {
       if (!e || e.alive === false) return;
       if (e.patrol && e.patrol.length >= 2) {
@@ -235,8 +236,9 @@ export default class BaseLevelScene extends Phaser.Scene {
         }
         const target = e.patrol[nextIndex];
         const dx = target.x - e.x;
-        const dist = Math.abs(dx);
-        if (dist < 2) {
+        const step = e.speed * dt;
+        if (Math.abs(dx) <= step) {
+          e.x = target.x;
           e.patrolIndex = nextIndex;
           e.setVelocityX(0);
         } else {
@@ -244,8 +246,13 @@ export default class BaseLevelScene extends Phaser.Scene {
           e.setVelocityX(vx);
           e.flipX = vx < 0;
         }
+        e.body.velocity.x = Phaser.Math.Clamp(
+          e.body.velocity.x,
+          -e.speed,
+          e.speed
+        );
       } else if (e.update) {
-        e.update();
+        e.update(time, delta);
       }
     });
   }


### PR DESCRIPTION
## Summary
- use delta and world timeScale to drive patrol logic deterministically
- clamp player and enemy velocities to avoid frame-rate spikes
- update enemy patrol to compute next position using delta time

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af613e91ec832aadaaaecdd4cead30