### PR TITLE
fix: prevent sockroach edge jitter

### DIFF
--- a/src/entities/Sockroach.js
+++ b/src/entities/Sockroach.js
@@ -50,17 +50,15 @@ export default class Sockroach extends Phaser.Physics.Arcade.Sprite {
     this.alive = true;
   }
 
-  update(_, delta) {
+  update() {
     if (!this.alive) return;
 
-    const dt = (delta / 1000) * this.scene.physics.world.timeScale;
-    const nextX = this.x + this.body.velocity.x * dt;
-
-    if (nextX <= this.patrolLeft) {
-      this.x = this.patrolLeft;
+    // Reverse direction if we hit the patrol bounds or world bounds
+    if (this.body.blocked.left || this.x <= this.patrolLeft) {
+      this.x = Math.max(this.x, this.patrolLeft);
       this.setVelocityX(this.speed);
-    } else if (nextX >= this.patrolRight) {
-      this.x = this.patrolRight;
+    } else if (this.body.blocked.right || this.x >= this.patrolRight) {
+      this.x = Math.min(this.x, this.patrolRight);
       this.setVelocityX(-this.speed);
     }
 


### PR DESCRIPTION
## Summary
- prevent sockroach enemy from jittering at patrol edges by reversing direction when touching bounds

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af62d9a3ec832a97d25e2584e52d95