### PR TITLE
Add responsive layout and mobile controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,13 +2,118 @@
 <html>
 <head>
   <meta charset="UTF-8" />
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover"
+  />
   <title>Lenny Toast Adventure</title>
   <style>
-    body { margin: 0; }
-    canvas { display: block; image-rendering: pixelated; }
+    :root {
+      color-scheme: dark;
+      --controls-padding: clamp(12px, 3vw, 32px);
+    }
+
+    html,
+    body {
+      height: 100%;
+      margin: 0;
+      background: #060607;
+      font-family: 'Courier New', Courier, monospace;
+    }
+
+    body {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+    }
+
+    #game-container {
+      position: relative;
+      width: 100vw;
+      height: 100vh;
+      max-width: 100vw;
+      max-height: 100vh;
+      overflow: hidden;
+      touch-action: none;
+    }
+
+    canvas {
+      display: block;
+      width: 100%;
+      height: 100%;
+      max-width: 100%;
+      max-height: 100%;
+      image-rendering: pixelated;
+      object-fit: contain;
+      background: #020203;
+    }
+
+    .mobile-controls {
+      position: absolute;
+      inset: 0;
+      display: none;
+      justify-content: space-between;
+      align-items: flex-end;
+      padding: var(--controls-padding);
+      padding-bottom: calc(var(--controls-padding) + env(safe-area-inset-bottom));
+      padding-left: calc(var(--controls-padding) + env(safe-area-inset-left));
+      padding-right: calc(var(--controls-padding) + env(safe-area-inset-right));
+      padding-top: calc(var(--controls-padding) + env(safe-area-inset-top));
+      pointer-events: none;
+      gap: clamp(12px, 5vw, 48px);
+    }
+
+    .mobile-controls--visible {
+      display: flex;
+    }
+
+    .mobile-controls__cluster {
+      display: flex;
+      gap: clamp(12px, 4vw, 36px);
+      pointer-events: auto;
+    }
+
+    .mobile-controls__cluster--dpad {
+      gap: clamp(8px, 3vw, 28px);
+    }
+
+    .mobile-controls__button {
+      width: clamp(64px, 18vw, 120px);
+      height: clamp(64px, 18vw, 120px);
+      border-radius: 50%;
+      border: 2px solid rgba(255, 255, 255, 0.3);
+      margin: 0;
+      padding: 0;
+      background: rgba(18, 20, 28, 0.75);
+      color: rgba(255, 255, 255, 0.9);
+      font-size: clamp(24px, 7vw, 44px);
+      font-weight: bold;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      backdrop-filter: blur(6px);
+      box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
+      touch-action: none;
+      transition: transform 0.1s ease, background 0.1s ease, border-color 0.1s ease;
+    }
+
+    .mobile-controls__button:active,
+    .mobile-controls__button[data-active='true'] {
+      transform: scale(0.95);
+      background: rgba(255, 180, 0, 0.9);
+      border-color: rgba(255, 220, 120, 0.9);
+      color: #140c02;
+    }
+
+    .mobile-controls__button:focus {
+      outline: none;
+    }
   </style>
 </head>
 <body>
+  <div id="game-container"></div>
   <script src="node_modules/phaser/dist/phaser.js"></script>
   <script type="module" src="src/game.js"></script>
 </body>

--- a/src/game.js
+++ b/src/game.js
@@ -7,9 +7,15 @@ document.title = `Lenny Toast Adventure ${VERSION}`;
 
 const config = {
   type: Phaser.AUTO,
-  width: GAME_WIDTH,
+  parent: 'game-container',
   pixelArt: true,
-  height: GAME_HEIGHT,
+  backgroundColor: '#000000',
+  scale: {
+    mode: Phaser.Scale.FIT,
+    autoCenter: Phaser.Scale.CENTER_BOTH,
+    width: GAME_WIDTH,
+    height: GAME_HEIGHT
+  },
   // Camera zoom is managed in Level1Scene after the map loads
   input: { gamepad: true },
   physics: {

--- a/src/scenes/BaseLevelScene.js
+++ b/src/scenes/BaseLevelScene.js
@@ -6,6 +6,7 @@ import InputService from '../services/InputService.js';
 import { createHUD, showLevelSuccess } from './systems/HUD.js';
 import { setupDebug } from './systems/DebugHelpers.js';
 import { spawnEnemy, spawnCollectible } from './systems/Spawners.js';
+import MobileControls from '../services/MobileControls.js';
 
 export default class BaseLevelScene extends Phaser.Scene {
   constructor(key, mapKey) {
@@ -132,6 +133,13 @@ export default class BaseLevelScene extends Phaser.Scene {
     Player.createAnimations(this);
     // Enemy animations are created on demand in their class
     this.inputService = new InputService(this);
+    this.mobileControls = new MobileControls(this, this.inputService);
+    this.events.once('shutdown', () => {
+      this.mobileControls = null;
+    });
+    this.events.once('destroy', () => {
+      this.mobileControls = null;
+    });
     this.player = new Player(this, spawnX, spawnY, this.inputService);
     this.spawnPoint = { x: spawnX, y: spawnY };
 

--- a/src/services/MobileControls.js
+++ b/src/services/MobileControls.js
@@ -1,0 +1,174 @@
+const coarseMedia = typeof window !== 'undefined' && window.matchMedia ? window.matchMedia('(pointer: coarse)') : null;
+
+const addCoarseListener = handler => {
+  if (!coarseMedia || !handler) return;
+  if (coarseMedia.addEventListener) {
+    coarseMedia.addEventListener('change', handler);
+  } else if (coarseMedia.addListener) {
+    coarseMedia.addListener(handler);
+  }
+};
+
+const removeCoarseListener = handler => {
+  if (!coarseMedia || !handler) return;
+  if (coarseMedia.removeEventListener) {
+    coarseMedia.removeEventListener('change', handler);
+  } else if (coarseMedia.removeListener) {
+    coarseMedia.removeListener(handler);
+  }
+};
+
+const shouldEnableControls = () => {
+  const coarse = coarseMedia?.matches;
+  if (coarse) return true;
+  const width = typeof window !== 'undefined' ? window.innerWidth : 0;
+  return width > 0 && width <= 1024;
+};
+
+const stopEvent = event => {
+  if (event) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+};
+
+export default class MobileControls {
+  constructor(scene, inputService) {
+    this.scene = scene;
+    this.inputService = inputService;
+    this.container = document.getElementById('game-container') || document.body;
+    this.root = document.createElement('div');
+    this.root.className = 'mobile-controls';
+    this.root.setAttribute('aria-hidden', 'true');
+
+    this._buttons = {};
+    this._active = { left: false, right: false, jump: false };
+
+    this._createLayout();
+
+    this.updateVisibility = this.updateVisibility.bind(this);
+    this.destroy = this.destroy.bind(this);
+
+    this.container.appendChild(this.root);
+    this.updateVisibility();
+
+    window.addEventListener('resize', this.updateVisibility);
+    addCoarseListener(this.updateVisibility);
+
+    scene.events.once('shutdown', this.destroy);
+    scene.events.once('destroy', this.destroy);
+  }
+
+  _createLayout() {
+    const dpad = document.createElement('div');
+    dpad.className = 'mobile-controls__cluster mobile-controls__cluster--dpad';
+
+    const jumpCluster = document.createElement('div');
+    jumpCluster.className = 'mobile-controls__cluster';
+
+    this.root.appendChild(dpad);
+    this.root.appendChild(jumpCluster);
+
+    this._buttons.left = this._createButton('◀', 'left', dpad);
+    this._buttons.right = this._createButton('▶', 'right', dpad);
+    this._buttons.jump = this._createButton('⤒', 'jump', jumpCluster);
+  }
+
+  _createButton(label, direction, parent) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'mobile-controls__button';
+    const ariaLabel =
+      direction === 'jump'
+        ? 'Jump'
+        : direction === 'left'
+        ? 'Move left'
+        : direction === 'right'
+        ? 'Move right'
+        : direction;
+    btn.setAttribute('aria-label', ariaLabel);
+    btn.textContent = label;
+    btn.setAttribute('aria-pressed', 'false');
+
+    const handlePress = event => {
+      stopEvent(event);
+      if (event?.pointerId != null && btn.setPointerCapture) {
+        try {
+          btn.setPointerCapture(event.pointerId);
+        } catch (err) {
+          // ignore capture errors
+        }
+      }
+      this._setActive(direction, true);
+    };
+
+    const releasePointer = event => {
+      if (event?.pointerId != null && btn.releasePointerCapture) {
+        try {
+          btn.releasePointerCapture(event.pointerId);
+        } catch (err) {
+          // ignore release errors
+        }
+      }
+    };
+
+    const handleRelease = event => {
+      stopEvent(event);
+      releasePointer(event);
+      this._setActive(direction, false);
+    };
+
+    const handleLeave = event => {
+      stopEvent(event);
+      releasePointer(event);
+      this._setActive(direction, false);
+    };
+
+    btn.addEventListener('pointerdown', handlePress);
+    btn.addEventListener('pointerup', handleRelease);
+    btn.addEventListener('pointercancel', handleLeave);
+    btn.addEventListener('pointerout', handleLeave);
+    btn.addEventListener('touchstart', handlePress, { passive: false });
+    btn.addEventListener('touchend', handleRelease, { passive: false });
+    btn.addEventListener('touchcancel', handleLeave, { passive: false });
+    btn.addEventListener('contextmenu', stopEvent);
+
+    parent.appendChild(btn);
+    return btn;
+  }
+
+  _setActive(direction, isActive) {
+    if (!this._buttons[direction]) return;
+    if (this._active[direction] === isActive) return;
+    this._active[direction] = isActive;
+    this._buttons[direction].dataset.active = String(isActive);
+    this._buttons[direction].setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    this.inputService.setMobileInput(direction, isActive);
+  }
+
+  updateVisibility() {
+    if (!this.root) return;
+    const visible = shouldEnableControls();
+    this.root.classList.toggle('mobile-controls--visible', visible);
+    this.root.setAttribute('aria-hidden', visible ? 'false' : 'true');
+    if (!visible) {
+      this._resetInputs();
+    }
+  }
+
+  _resetInputs() {
+    Object.keys(this._active).forEach(direction => this._setActive(direction, false));
+  }
+
+  destroy() {
+    if (!this.root) return;
+    this._resetInputs();
+    window.removeEventListener('resize', this.updateVisibility);
+    removeCoarseListener(this.updateVisibility);
+    if (this.root?.parentElement) {
+      this.root.parentElement.removeChild(this.root);
+    }
+    this.root = null;
+    this.scene = null;
+  }
+}


### PR DESCRIPTION
## Summary
- add responsive layout styles and viewport metadata to support mobile and tablet layouts
- implement a reusable MobileControls helper that renders on-screen movement and jump buttons
- integrate the mobile controls with BaseLevelScene and update Phaser scaling to fit the viewport

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cae185e8cc832a985177d14d027368