### PR TITLE
Add responsive level stats tracking and success layout

### DIFF
--- a/src/scenes/BaseLevelScene.js
+++ b/src/scenes/BaseLevelScene.js
@@ -7,6 +7,7 @@ import { createHUD, showLevelSuccess } from './systems/HUD.js';
 import { setupDebug } from './systems/DebugHelpers.js';
 import { spawnEnemy, spawnCollectible } from './systems/Spawners.js';
 import MobileControls from '../services/MobileControls.js';
+import { resetLevelStats, addSockroachKill, setRawLevelTime } from '../services/LevelStats.js';
 
 export default class BaseLevelScene extends Phaser.Scene {
   constructor(key, mapKey) {
@@ -19,6 +20,8 @@ export default class BaseLevelScene extends Phaser.Scene {
     this.levelStartTime = this.time.now;
     this.isLevelComplete = false;
     this.levelEndZone = null;
+    resetLevelStats();
+    this.sockroachKills = 0;
     // --- Map + tiles ---
     const map = this.make.tilemap({ key: this.mapKey });
     const tiles = map.addTilesetImage(
@@ -304,6 +307,7 @@ export default class BaseLevelScene extends Phaser.Scene {
       onComplete: () => {
         this.player.setVisible(false);
         const elapsed = (this.time.now - this.levelStartTime) / 1000;
+        setRawLevelTime(elapsed);
         showLevelSuccess(this, elapsed, this.mapKey || this.scene.key);
       }
     });
@@ -327,6 +331,7 @@ export default class BaseLevelScene extends Phaser.Scene {
       playerObj.setVelocityY(-300);
       enemy.body.checkCollision.none = true;
       enemy.setCollideWorldBounds(false);
+      this.sockroachKills = addSockroachKill();
       enemy.once('animationcomplete-sockroach_stomp', () => {
         enemy.setVelocityY(-200);
         this.time.delayedCall(1000, () => enemy.destroy());

--- a/src/services/LevelStats.js
+++ b/src/services/LevelStats.js
@@ -1,0 +1,51 @@
+const stats = {
+  toastCount: 0,
+  sockroachKills: 0,
+  rawLevelTime: 0
+};
+
+const toNumber = value => {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : 0;
+};
+
+export function resetLevelStats() {
+  stats.toastCount = 0;
+  stats.sockroachKills = 0;
+  stats.rawLevelTime = 0;
+}
+
+export function addToast(count = 1) {
+  const inc = Math.max(0, toNumber(count));
+  stats.toastCount += inc;
+  return stats.toastCount;
+}
+
+export function addSockroachKill(count = 1) {
+  const inc = Math.max(0, toNumber(count));
+  stats.sockroachKills += inc;
+  return stats.sockroachKills;
+}
+
+export function setToastCount(count = 0) {
+  stats.toastCount = Math.max(0, toNumber(count));
+  return stats.toastCount;
+}
+
+export function setSockroachKills(count = 0) {
+  stats.sockroachKills = Math.max(0, toNumber(count));
+  return stats.sockroachKills;
+}
+
+export function setRawLevelTime(seconds = 0) {
+  stats.rawLevelTime = Math.max(0, toNumber(seconds));
+  return stats.rawLevelTime;
+}
+
+export function getLevelStats() {
+  return {
+    toastCount: stats.toastCount,
+    sockroachKills: stats.sockroachKills,
+    rawLevelTime: stats.rawLevelTime
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared LevelStats helper to track toasts, sockroach defeats, and raw level time
- reset and update those stats from gameplay events so the level complete flow can compute final time bonuses
- redesign the level complete UI with a scroll-safe layout that highlights time savings, final time, and leaderboard entries

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbd105e47c832a81e9fdfb44c259ea