### PR TITLE
Add lives lost penalty to final time and enlarge success screen

### DIFF
--- a/src/scenes/BaseLevelScene.js
+++ b/src/scenes/BaseLevelScene.js
@@ -7,7 +7,7 @@ import { createHUD, showLevelSuccess } from './systems/HUD.js';
 import { setupDebug } from './systems/DebugHelpers.js';
 import { spawnEnemy, spawnCollectible } from './systems/Spawners.js';
 import MobileControls from '../services/MobileControls.js';
-import { resetLevelStats, addSockroachKill, setRawLevelTime } from '../services/LevelStats.js';
+import { resetLevelStats, addSockroachKill, setRawLevelTime, addLifeLost } from '../services/LevelStats.js';
 
 export default class BaseLevelScene extends Phaser.Scene {
   constructor(key, mapKey) {
@@ -391,6 +391,7 @@ export default class BaseLevelScene extends Phaser.Scene {
       if (this.isInvincible) return;
       sfx('hurt');
       this.health -= 1;
+      addLifeLost();
       this.removeHealthIcon();
       this.isInvincible = true;
       playerObj.setTint(0xff0000);

--- a/src/scenes/systems/HUD.js
+++ b/src/scenes/systems/HUD.js
@@ -270,8 +270,8 @@ export function showLevelSuccess(scene, timeTaken, levelId) {
 
   const safeMargin = Math.max(32, GAME_HEIGHT * 0.08);
   const panelMaxHeight = GAME_HEIGHT - safeMargin * 2;
-  const panelW = Math.min(760, GAME_WIDTH * 0.9);
-  const desiredPanelH = 620;
+  const panelW = Math.min(900, GAME_WIDTH * 0.95);
+  const desiredPanelH = 720;
   let panelH = Math.min(desiredPanelH, panelMaxHeight);
   if (panelMaxHeight >= 420) {
     panelH = Math.max(panelH, 420);
@@ -291,7 +291,9 @@ export function showLevelSuccess(scene, timeTaken, levelId) {
   const rawTime = stats.rawLevelTime > 0 ? stats.rawLevelTime : timeTaken;
   const toastSavings = toastCount * 0.1;
   const sockroachSavings = sockroachKills * 0.25;
-  const finalTime = Math.max(0, rawTime - toastSavings - sockroachSavings);
+  const livesLost = stats.livesLost || 0;
+  const lifePenalty = livesLost * 1;
+  const finalTime = Math.max(0, rawTime - toastSavings - sockroachSavings + lifePenalty);
   const formatSeconds = value => `${value.toFixed(2)}s`;
 
   const buttonHeight = 72;
@@ -327,9 +329,13 @@ export function showLevelSuccess(scene, timeTaken, levelId) {
           <span style="flex:1; min-width:0;">Sockroaches defeated</span>
           <span style="text-align:right; white-space:nowrap;">${sockroachKills}</span>
         </div>
+        <div style="display:flex; justify-content:space-between; gap:12px; font-size:22px; font-weight:bold;">
+          <span style="flex:1; min-width:0;">Lives lost</span>
+          <span style="text-align:right; white-space:nowrap;">${livesLost}</span>
+        </div>
       </section>
       <section style="margin-bottom:18px;">
-        <h3 style="margin:0 0 12px; font-size:24px; font-weight:bold; text-align:left;">Time Savings</h3>
+        <h3 style="margin:0 0 12px; font-size:24px; font-weight:bold; text-align:left;">Time Adjustments</h3>
         <div style="display:flex; justify-content:space-between; gap:12px; margin-bottom:8px; font-size:20px;">
           <span style="flex:1; min-width:0;">Time saved (toasts)</span>
           <span style="text-align:right; white-space:nowrap;">${toastCount} × 0.10s = ${toastSavings.toFixed(2)}s</span>
@@ -337,6 +343,10 @@ export function showLevelSuccess(scene, timeTaken, levelId) {
         <div style="display:flex; justify-content:space-between; gap:12px; margin-bottom:12px; font-size:20px;">
           <span style="flex:1; min-width:0;">Time saved (Sockroaches)</span>
           <span style="text-align:right; white-space:nowrap;">${sockroachKills} × 0.25s = ${sockroachSavings.toFixed(2)}s</span>
+        </div>
+        <div style="display:flex; justify-content:space-between; gap:12px; margin-bottom:12px; font-size:20px; color:#aa1111;">
+          <span style="flex:1; min-width:0;">Time penalty (lives lost)</span>
+          <span style="text-align:right; white-space:nowrap;">${livesLost} × 1.00s = ${lifePenalty.toFixed(2)}s</span>
         </div>
         <div style="display:flex; justify-content:space-between; gap:12px; margin-bottom:6px; font-size:20px;">
           <span style="flex:1; min-width:0;">Raw time</span>

--- a/src/services/LevelStats.js
+++ b/src/services/LevelStats.js
@@ -1,7 +1,8 @@
 const stats = {
   toastCount: 0,
   sockroachKills: 0,
-  rawLevelTime: 0
+  rawLevelTime: 0,
+  livesLost: 0
 };
 
 const toNumber = value => {
@@ -13,6 +14,7 @@ export function resetLevelStats() {
   stats.toastCount = 0;
   stats.sockroachKills = 0;
   stats.rawLevelTime = 0;
+  stats.livesLost = 0;
 }
 
 export function addToast(count = 1) {
@@ -25,6 +27,12 @@ export function addSockroachKill(count = 1) {
   const inc = Math.max(0, toNumber(count));
   stats.sockroachKills += inc;
   return stats.sockroachKills;
+}
+
+export function addLifeLost(count = 1) {
+  const inc = Math.max(0, toNumber(count));
+  stats.livesLost += inc;
+  return stats.livesLost;
 }
 
 export function setToastCount(count = 0) {
@@ -46,6 +54,7 @@ export function getLevelStats() {
   return {
     toastCount: stats.toastCount,
     sockroachKills: stats.sockroachKills,
-    rawLevelTime: stats.rawLevelTime
+    rawLevelTime: stats.rawLevelTime,
+    livesLost: stats.livesLost
   };
 }


### PR DESCRIPTION
## Summary
- track lives lost in level stats and add a one second penalty per lost life to the final time shown and submitted
- surface lives lost and the new penalty in the level complete UI alongside existing time adjustments
- enlarge the success panel dimensions to better fill larger displays

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbf3aab06c832a8e719bd532a7c19c