### PR TITLE
Add welcome screen scene before starting game

### DIFF
--- a/src/assets/manifest.js
+++ b/src/assets/manifest.js
@@ -24,6 +24,7 @@ const manifest = {
     { key: 'toast', url: new URL('./sprites/toast/toast_sprite.png', import.meta.url).href },
     { key: 'lenny_face', url: new URL('./sprites/lenny/lenny_face.png', import.meta.url).href },
     { key: 'game_over', url: new URL('./sprites/game/game_over.png', import.meta.url).href },
+    { key: 'welcome_screen', url: new URL('./sprites/game/welcome_screen.png', import.meta.url).href },
     { key: 'tiles', url: new URL('../levels/level1/nature-paltformer-tileset-16x16.png', import.meta.url).href },
     { key: 'ui_frame', url: new URL('./ui/Sprites/UI_Flat_Frame02a.png', import.meta.url).href },
     { key: 'ui_btn02_1', url: new URL('./ui/Sprites/UI_Flat_Button02a_1.png', import.meta.url).href },

--- a/src/game.js
+++ b/src/game.js
@@ -1,6 +1,7 @@
 import { VERSION, GAME_WIDTH, GAME_HEIGHT, DEBUG } from './constants.js';
 import BootScene from './scenes/BootScene.js';
 import PreloadScene from './scenes/PreloadScene.js';
+import WelcomeScene from './scenes/WelcomeScene.js';
 import Level1Scene from './scenes/Level1Scene.js';
 
 document.title = `Lenny Toast Adventure ${VERSION}`;
@@ -24,7 +25,7 @@ const config = {
     default: 'arcade',
     arcade: { gravity: { y: 700 }, debug: DEBUG.enabled }
   },
-  scene: [BootScene, PreloadScene, Level1Scene]
+  scene: [BootScene, PreloadScene, WelcomeScene, Level1Scene]
 };
 
 new Phaser.Game(config);

--- a/src/scenes/PreloadScene.js
+++ b/src/scenes/PreloadScene.js
@@ -32,6 +32,6 @@ export default class PreloadScene extends Phaser.Scene {
   }
 
   create() {
-    this.scene.start('Level1');
+    this.scene.start('Welcome');
   }
 }

--- a/src/scenes/WelcomeScene.js
+++ b/src/scenes/WelcomeScene.js
@@ -1,0 +1,47 @@
+/* global Phaser */
+import { GAME_WIDTH, GAME_HEIGHT } from '../constants.js';
+
+export default class WelcomeScene extends Phaser.Scene {
+  constructor() {
+    super('Welcome');
+  }
+
+  create() {
+    const width = this.scale?.width || GAME_WIDTH;
+    const height = this.scale?.height || GAME_HEIGHT;
+
+    this.cameras.main.setBackgroundColor('#000000');
+
+    const frame = this.add.image(width / 2, height / 2, 'ui_frame');
+    const maxFrameWidth = width * 0.8;
+    const maxFrameHeight = height * 0.8;
+    const frameScale = Math.min(maxFrameWidth / frame.width, maxFrameHeight / frame.height);
+    frame.setScale(frameScale);
+
+    const welcomeImage = this.add.image(width / 2, height / 2, 'welcome_screen');
+    const innerWidth = frame.displayWidth * 0.88;
+    const innerHeight = frame.displayHeight * 0.88;
+    const welcomeScale = Math.min(innerWidth / welcomeImage.width, innerHeight / welcomeImage.height);
+    welcomeImage.setScale(welcomeScale);
+
+    const prompt = this.add.text(width / 2, height * 0.85, 'Press SPACE or Click to Start', {
+      fontFamily: 'monospace',
+      fontSize: '48px',
+      color: '#ffffff',
+      stroke: '#000000',
+      strokeThickness: 6
+    });
+    prompt.setOrigin(0.5);
+
+    this.input.keyboard.once('keydown-SPACE', this.startGame, this);
+    this.input.keyboard.once('keydown-ENTER', this.startGame, this);
+    this.input.once('pointerdown', this.startGame, this);
+    if (this.input.gamepad) {
+      this.input.gamepad.once('down', this.startGame, this);
+    }
+  }
+
+  startGame() {
+    this.scene.start('Level1');
+  }
+}


### PR DESCRIPTION
## Summary
- add the welcome screen sprite to the asset manifest
- create a welcome scene that frames the new image with existing UI art and waits for input
- route the preload flow through the welcome scene before entering Level 1

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbfe309fc0832abaed122cc306083f