### PR TITLE
Add leaderboard view to pause menu

### DIFF
--- a/src/scenes/systems/HUD.js
+++ b/src/scenes/systems/HUD.js
@@ -804,7 +804,7 @@ export function showPauseMenu(scene) {
     .setOrigin(0, 0);
   leaderboardEntries.setWordWrapWidth(panelW - 120);
   leaderboardEntries.setLineSpacing(4);
-  const leaderboardMaskShape = scene.make.graphics({ x: 0, y: 0, add: false });
+  const leaderboardMaskShape = scene.make.graphics({ x: panelX, y: panelY, add: false });
   leaderboardMaskShape.fillStyle(0xffffff, 1);
   leaderboardMaskShape.fillRect(-panelW / 2 + 50, leaderboardListTop, panelW - 100, leaderboardListHeight);
   const leaderboardMask = leaderboardMaskShape.createGeometryMask();


### PR DESCRIPTION
## Summary
- add a Leaderboard button to the pause menu alongside existing options
- show a dedicated leaderboard panel that fetches the current level results and displays the top 25 runs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc27d6fc50832abf774f72814d6e23