### PR TITLE
Add Evanbb speed boost cheat code

### DIFF
--- a/src/entities/Player.js
+++ b/src/entities/Player.js
@@ -1,5 +1,17 @@
 import { sfx } from '../AudioBus.js';
 
+const SPEED_CHEAT_KEY = 'lenny-toast-speedboost';
+
+function getSpeedMultiplier() {
+  if (typeof window === 'undefined') return 1;
+  try {
+    return window.localStorage?.getItem(SPEED_CHEAT_KEY) === '1' ? 1.15 : 1;
+  } catch (err) {
+    console.warn('Unable to read speed cheat flag.', err);
+    return 1;
+  }
+}
+
 export default class Player extends Phaser.Physics.Arcade.Sprite {
   static createAnimations(scene) {
     scene.anims.create({
@@ -43,6 +55,7 @@ export default class Player extends Phaser.Physics.Arcade.Sprite {
     // Store input service under a non-reserved property to avoid clashing
     // with Phaser's own `input` component on game objects
     this.inputService = inputService;
+    this.moveSpeed = 160 * getSpeedMultiplier();
     this.jumpCount = 0;
   }
 
@@ -51,11 +64,11 @@ export default class Player extends Phaser.Physics.Arcade.Sprite {
     if (onGround) this.jumpCount = 0;
 
     if (this.inputService.left()) {
-      this.setVelocityX(-160);
+      this.setVelocityX(-this.moveSpeed);
       this.setFlipX(true);
       if (onGround) this.play('walk', true);
     } else if (this.inputService.right()) {
-      this.setVelocityX(160);
+      this.setVelocityX(this.moveSpeed);
       this.setFlipX(false);
       if (onGround) this.play('walk', true);
     } else {

--- a/src/scenes/systems/HUD.js
+++ b/src/scenes/systems/HUD.js
@@ -5,6 +5,23 @@ import { shouldEnableControls } from '../../services/MobileControls.js';
 import { getLeaderboard, addRun } from '../../services/LeaderboardService.js';
 import { getLevelStats, addToast, setToastCount } from '../../services/LevelStats.js';
 
+const SPEED_CHEAT_KEY = 'lenny-toast-speedboost';
+
+const isSpeedCheatEnabled = () => {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage?.getItem(SPEED_CHEAT_KEY) === '1';
+  } catch (err) {
+    console.warn('Unable to read speed cheat flag.', err);
+    return false;
+  }
+};
+
+const updatePauseButtonIcon = scene => {
+  if (!scene?.pauseButtonIcon) return;
+  scene.pauseButtonIcon.setText(isSpeedCheatEnabled() ? 'P' : 'II');
+};
+
 const formatTimer = seconds => {
   const total = Math.max(0, Number(seconds) || 0);
   const minutes = Math.floor(total / 60);
@@ -94,6 +111,8 @@ export function createHUD(scene) {
     btn.add([bg, icon, zone]);
     scene.ui.add(btn);
     scene.pauseButton = btn;
+    scene.pauseButtonIcon = icon;
+    updatePauseButtonIcon(scene);
   }
 
   // Health icons
@@ -315,7 +334,6 @@ export function showGameOver(scene) {
 
 export function showLevelSuccess(scene, timeTaken, levelId) {
   const resolvedLevelId = levelId || scene.mapKey || scene.scene.key || 'default';
-  const SPEED_CHEAT_KEY = 'lenny-toast-speedboost';
   const loadLastName = () => {
     if (typeof window === 'undefined') return '';
     try {
@@ -337,6 +355,7 @@ export function showLevelSuccess(scene, timeTaken, levelId) {
     if (typeof window === 'undefined') return;
     try {
       window.localStorage?.setItem(SPEED_CHEAT_KEY, '1');
+      updatePauseButtonIcon(scene);
     } catch (err) {
       console.warn('Unable to store speed cheat flag.', err);
     }

--- a/src/scenes/systems/HUD.js
+++ b/src/scenes/systems/HUD.js
@@ -315,6 +315,7 @@ export function showGameOver(scene) {
 
 export function showLevelSuccess(scene, timeTaken, levelId) {
   const resolvedLevelId = levelId || scene.mapKey || scene.scene.key || 'default';
+  const SPEED_CHEAT_KEY = 'lenny-toast-speedboost';
   const loadLastName = () => {
     if (typeof window === 'undefined') return '';
     try {
@@ -330,6 +331,14 @@ export function showLevelSuccess(scene, timeTaken, levelId) {
       window.localStorage?.setItem('lenny-toast-lastname', name);
     } catch (err) {
       console.warn('Unable to store leaderboard name.', err);
+    }
+  };
+  const enableSpeedCheat = () => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage?.setItem(SPEED_CHEAT_KEY, '1');
+    } catch (err) {
+      console.warn('Unable to store speed cheat flag.', err);
     }
   };
 
@@ -601,7 +610,11 @@ export function showLevelSuccess(scene, timeTaken, levelId) {
       try {
         const { entries, entry, rank } = await addRun(resolvedLevelId, sanitizedName, finalTime);
         updateLeaderboardDisplay(entries);
-        storeLastName(entry?.name || sanitizedName);
+        const savedName = entry?.name || sanitizedName;
+        storeLastName(savedName);
+        if (savedName === 'Evanbb') {
+          enableSpeedCheat();
+        }
         hasSavedRun = true;
         formDom.setVisible(false);
         if (typeof formDom.node.reset === 'function') formDom.node.reset();

--- a/src/scenes/systems/HUD.js
+++ b/src/scenes/systems/HUD.js
@@ -361,6 +361,16 @@ export function showLevelSuccess(scene, timeTaken, levelId) {
     }
   };
 
+  const disableSpeedCheat = () => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage?.removeItem(SPEED_CHEAT_KEY);
+      updatePauseButtonIcon(scene);
+    } catch (err) {
+      console.warn('Unable to clear speed cheat flag.', err);
+    }
+  };
+
   const overlay = scene.add.container(0, 0).setScrollFactor(0).setDepth(10000);
   const dim = scene.add
     .rectangle(0, 0, GAME_WIDTH, GAME_HEIGHT, 0x000000, 0.6)
@@ -633,6 +643,8 @@ export function showLevelSuccess(scene, timeTaken, levelId) {
         storeLastName(savedName);
         if (savedName === 'Evanbb') {
           enableSpeedCheat();
+        } else {
+          disableSpeedCheat();
         }
         hasSavedRun = true;
         formDom.setVisible(false);


### PR DESCRIPTION
## Summary
- persist a hidden speed boost flag when a run is saved under the name "Evanbb"
- apply a 15% movement speed bonus for future player instances when the cheat flag is present

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cd9c603b30832a8b7d6a5b21263c88